### PR TITLE
Update gg2fig as gg2list

### DIFF
--- a/What_You_Need/plotlyGraphWidget.R
+++ b/What_You_Need/plotlyGraphWidget.R
@@ -12,17 +12,10 @@ graphOutput <- function(inputId, width="100%", height="550px") {
     )
 }
 
-#Function to change ggplot figure into plotly syntax
-#gg is the users ggplot
-#called in the server script to return data and layout info separately 
-gg2fig <- function(gg) {
-	fig <- gg2list(gg)
-	data <- list()
-	for(i in 1:(length(fig)-1)){data[[i]]<-fig[[i]]}
-	layout <- fig$kwargs$layout
-	result <- list(data=data,layout=layout)
-	return(result)
-} 
+# Function to change ggplot figure into plotly syntax
+# Takes gg (the user's ggplot) as argument.
+# Provided by gg2list directly since package version 0.5.30 
+gg2fig <- gg2list
 
 renderGraph <- function(expr, env=parent.frame(), quoted=FALSE) {
     ## This gets called when inputs change --


### PR DESCRIPTION
Following https://github.com/ropensci/plotly/pull/210

I thought I would make this change as invisible as possible... Because `gg2fig` has been communicated about already... Otherwise we should replace all these instances of `gg2fig` by `gg2list`:

```
marianne@marianne-thinkpad:~/plotly/plotly-shiny(master)$ ack gg2fig
What_You_Need/plotlyGraphWidget.R
18:gg2fig <- function(gg) {

What_You_Need/server_Template_GGPLOT.R
17: gg<- gg2fig(YOUR_PLOT)

Examples/UN_Advanced/plotlyGraphWidget.R
18:gg2fig <- function(gg) {

Examples/UN_Advanced/server.R
46:      gg<- gg2fig(ggideal_point)

Examples/Diamonds/plotlyGraphWidget.R
18:gg2fig <- function(gg) {

Examples/Diamonds/server.R
27:     gg <- gg2fig(p)

Examples/UN_Simple/plotlyGraphWidget.R
18:gg2fig <- function(gg) {

Examples/UN_Simple/server.R
26:      gg<- gg2fig(ggideal_point)

Examples/Movies/plotlyGraphWidget.R
18:gg2fig <- function(gg) {
```

/cc @cldougl @chriddyp
